### PR TITLE
[MOD] bump version to 2.0.0, description in CHANGELOG.md, change word…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.0] - Unreleased
+## [2.0.0] - 2020-11-01
+### Added
+- Documentation, more usage examples in README.md, comments in code
+
 ### Changed
-- BREAKING: MessageHandler process interface to take calling context as first parameter, to handle 'this' in function call properly. This will break custom message handler implementations.
+- BREAKING: MessageHandler process interface to take calling context as first parameter, to handle 'this' in function call properly. This WILL BREAK custom message handler implementations. If you used the provided message handlers, the changes are backwards compatible.
 
 ## [1.0.3] - 2020-09-03
 ### Changed

--- a/README.md
+++ b/README.md
@@ -119,9 +119,9 @@ const app = express();
 const server = http.createServer(app);
 
 // pass message handler instances and WebSocket.ServerOptions to the respective namespaces
-const namespaceA = new RPCNamespaceA(new SimpleMessageHandler(), { noServer: true });
+const namespaceA = new NamespaceA(new SimpleMessageHandler(), { noServer: true });
 // use different message handlers for different namespaces
-const namespaceB = new RPCNamespaceB(new JSONRPC2MessageHandler(), { noServer: true });
+const namespaceB = new NamespaceB(new JSONRPC2MessageHandler(), { noServer: true });
 
 
 server.on('upgrade', function upgrade(request, socket, head) {
@@ -192,7 +192,8 @@ Currently, the [WebSocketServer](https://github.com/JohnBra/rpc-websocketserver/
 
 All protected functions can be overridden for your specific namespaces. You are encouraged to override the 'onConnection' handler with handlers for the possible [ws events](https://github.com/websockets/ws/blob/master/doc/ws.md#event-close-1) (e. g. error) like so:
 ```typescript
-import { WebSocketServer, register, param } from 'rpc-websocketserver';
+import WebSocket from 'ws';
+import { MessageHandler, WebSocketServer, register, param } from 'rpc-websocketserver';
 
 // inherit from WebSocketServer
 class NamespaceA extends WebSocketServer {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rpc-websocketserver",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "Simple rpc websocket server, wrapping the very popular 'ws' library. Register your RPCs with convenient decorators.",
   "keywords": [
     "RPC",


### PR DESCRIPTION
### Added
- Documentation, more usage examples in README.md, comments in code

### Changed
- BREAKING: MessageHandler process interface to take calling context as first parameter, to handle 'this' in function call properly. This WILL BREAK custom message handler implementations. If you used the provided message handlers, the changes are backwards compatible.
